### PR TITLE
Skip CI on the post release version bump commit

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -41,5 +41,5 @@ runs:
       uses: EndBug/add-and-commit@v7
       with:
         branch: main
-        message: "Post release version bump"
+        message: "Post release version bump\n\n[skip ci]"
         add: "-u *"


### PR DESCRIPTION
It never makes sense to release this particular commit as it has nothing
over the previous release. Consequently running CI on this commit is
just a waste of CPU cycles.