### PR TITLE
Exclude pgp signature from GitHub release

### DIFF
--- a/release-info.sh
+++ b/release-info.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 TAG=$(git describe "${GITHUB_REF}")
-git tag --list --format="%(subject)%0a%(body)" $TAG > release.md
+git tag --list --format="%(subject)%0a%(body)" $TAG | sed '/^-----BEGIN PGP SIGNATURE-----$/,$d' > release.md
 echo "release_version=${TAG//v}" >> $GITHUB_ENV


### PR DESCRIPTION
The body element of the git tag also contains the PGP signature but we don't necessarily want to have this in the GitHub release text, so `sed` it away.