### PR TITLE
Send an announcement to the osbuild Slack channel

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,9 @@ inputs:
   token:
     description: "A GitHub token for creating a release"
     required: true
+  slack_webhook_url:
+    description: "A Slack incoming Webhook URL"
+    required: true
 
 runs:
   using: "composite"
@@ -43,3 +46,12 @@ runs:
         branch: main
         message: "Post release version bump\n\n[skip ci]"
         add: "-u *"
+
+    - name: Send release announcement to osbuild Slack channel
+      id: slack
+      uses: slackapi/slack-github-action@v1.16.0
+      with:
+        payload: "{\"blocks\":[{\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"🚀 *<https://github.com/osbuild/${{  env.component }}/releases/tag/v${{  env.release_version }}|${{  env.component }} ${{  env.release_version }}>* just got released upstream! 🚀\"}}]}"
+      env:
+        SLACK_WEBHOOK_URL: ${{ inputs.SLACK_WEBHOOK_URL }}
+        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/release-info.sh
+++ b/release-info.sh
@@ -3,3 +3,4 @@
 TAG=$(git describe "${GITHUB_REF}")
 git tag --list --format="%(subject)%0a%(body)" $TAG | sed '/^-----BEGIN PGP SIGNATURE-----$/,$d' > release.md
 echo "release_version=${TAG//v}" >> $GITHUB_ENV
+echo "component=$(basename `git rev-parse --show-toplevel`)" >> $GITHUB_ENV


### PR DESCRIPTION
This uses Slack's GitHub Action to send a release announcement notification to the osbuild Slack channel. The format of the message is rather icky because it's escaped json, but it was tested successfully on the #bot-testing channel.
The notification shall replace the current - super-verbose - rss notification, which is also triggered if someone changes a release note by hand after the release has already been done.

Unfortunately GitHub composite actions cannot handle secrets, so the incoming webhook URL will have to be stored as a secret either in the osbuild organisation or in each repository that uses this action and then be passed down as an input parameter (much like the GitHub token).
For the time being I have added a (scoped) organisation secret that is only available to the osbuild and osbuild-composer repositories.

See the two related PRs:
- https://github.com/osbuild/osbuild/pull/935
- https://github.com/osbuild/osbuild-composer/pull/2117