### PR TITLE
Adjust regex to also match koji-osbuild

### DIFF
--- a/bump-version.sh
+++ b/bump-version.sh
@@ -2,7 +2,7 @@
 
 VERSION=$(( $1 + 1 ))
 
-sed -i -E "s/(Version:\\s+)[0-9].+/\1$VERSION/" osbuild*.spec
+sed -i -E "s/(Version:\\s+)[0-9]+/\1$VERSION/" *osbuild*.spec
 
 if [ -f "setup.py" ]; then
   sed -i -E "s/(version=\")[0-9]+/\1$VERSION/" setup.py


### PR DESCRIPTION
Without dropping the `.` the regex didn't match `koji-osbuild.spec` because its version number is still in the single digits. 