### PR TITLE
Cleanup code

### DIFF
--- a/create_tag.py
+++ b/create_tag.py
@@ -107,7 +107,6 @@ def get_pullrequest_infos(args, repo, hashes):
                 msg = f"  * {pull_request.title} (#{pull_request.number})"
             summaries.append(msg)
 
-    summaries = list(dict.fromkeys(summaries))
     msg_ok(f"Collected summaries from {len(summaries)} pull requests ({i} commits).")
     return "\n".join(summaries)
 

--- a/create_tag.py
+++ b/create_tag.py
@@ -116,6 +116,7 @@ def get_contributors(latest_tag):
     logging.debug("Collect contributors...")
     contributors = run_command(["git", "log", '--format="%an"', f"{latest_tag}..HEAD"])
     contributor_list = contributors.replace('"', '').split("\n")
+    contributor_list.pop() # Remove the author of the post release version bump commit
     names = ""
     for name in sorted(set(contributor_list)):
         if name != "":


### PR DESCRIPTION
This PR does two things. Firstly it drops a superfluous line from a previous version of this script. Secondly, it removes the author of the post release version bump commit that is created by the action on this repository's main branch since it's most likely a bot (and because the git author information doesn't look nice).