### PR TITLE
Bump version in osbuild/__init__.py as well

### DIFF
--- a/bump-version.sh
+++ b/bump-version.sh
@@ -7,3 +7,7 @@ sed -i -E "s/(Version:\\s+)[0-9]+/\1$VERSION/" *osbuild*.spec
 if [ -f "setup.py" ]; then
   sed -i -E "s/(version=\")[0-9]+/\1$VERSION/" setup.py
 fi
+
+if [ -f "osbuild/__init__.py" ]; then
+  sed -i "s|__version__ = \"$(VERSION)\"|__version__ = \"$(NEXT_VERSION)\"|" osbuild/__init__.py
+fi


### PR DESCRIPTION
This change is so that the `osbuild --version` command works as it should.

I have taken the `sed` line directly from the Makefile in the proposed version PR, so hoping it'll all work.

See https://github.com/osbuild/osbuild/pull/1039