### PR TITLE
Fix version bumping in osbuild/__init__.py

### DIFF
--- a/bump-version.sh
+++ b/bump-version.sh
@@ -9,5 +9,5 @@ if [ -f "setup.py" ]; then
 fi
 
 if [ -f "osbuild/__init__.py" ]; then
-  sed -i "s|__version__ = \"$(VERSION)\"|__version__ = \"$(NEXT_VERSION)\"|" osbuild/__init__.py
+  sed -i -E "s/(__version__ = \")[0-9]+/\1$VERSION/" osbuild/__init__.py
 fi


### PR DESCRIPTION
This commit makes the sed line consistent and doesn't use non-existing variables.

I've tested this change locally to make sure it behaves as expected.