### PR TITLE
Optionally support semantic versioning for release tags

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,10 @@ inputs:
   email:
     description: "The GitHub user's email address"
     required: true
+  semver:
+    description: "Use semantic versioning instead of a single number"
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -41,5 +45,10 @@ runs:
     - name: Create and push tag
       run: |
         cd ${{ github.action_path }}/${{ env.REPOSITORY_NAME }}/
-        ${{ github.action_path }}/create_tag.py --token "${{ inputs.TOKEN }}"
+        if [[ "${{ inputs.SEMVER }}" == "true" ]]; then
+          VERSION_TYPE_OPTION="--semver"
+        else
+          VERSION_TYPE_OPTION=""
+        fi
+        ${{ github.action_path }}/create_tag.py --token "${{ inputs.TOKEN }}" $VERSION_TYPE_OPTION
       shell: bash

--- a/create_tag.py
+++ b/create_tag.py
@@ -188,7 +188,7 @@ def get_parser():
     parser.add_argument("--semver",
                         action="store_true",
                         default=False,
-                        help="Use semantic versioning, instead of a simple autoincrement. Note that only the fist" + \
+                        help="Use semantic versioning, instead of a simple autoincrement. Note that only the first" + \
                         " number will be incremented and following numbers will be reset to zero.")
     parser.add_argument("--dry-run",
                         action="store_true",


### PR DESCRIPTION
Add an option to create new tag for a release using semantic versioning by incrementing the major version and zeroing the rest of the version.