### PR TITLE
Fix case of pushing a first tag for a repo with one commit

### DIFF
--- a/create_tag.py
+++ b/create_tag.py
@@ -145,7 +145,9 @@ def create_release_tag(args, repo, tag, latest_tag):
     msg_info(f"Found {len(hashes)} commits since {latest_tag} in {args.base}:")
     logging.debug("\n".join(hashes))
 
-    if len(hashes) <= 1: # Don't release when there are no changes
+    subjects = run_command(['git', 'log', '--format=%s', f'{latest_tag}..HEAD']).split("\n")
+    # Don't release when there are no changes
+    if (len(hashes) < 1) or (len(subjects) == 1 and subjects[0] == "Post release version bump"):
         msg_info("No new commits have been pushed since the latest release (apart from the post release version bump) therefore skipping the tag.")
         sys.exit(0)
 


### PR DESCRIPTION
The script would skip pushing a tag if there is only one new commit in the repository, but it is not the one that bumps the version post-release. Check for this specific case and push tags even if there is just a single new functional commit.

E.g. from https://github.com/osbuild/ansible-osbuild-worker/actions/runs/5324647147/jobs/9644333125

```
Info: There are no tags yet in this repository.

--------------------------------
Release:
  Component:     ansible-osbuild-worker
  Version:       1.0.0
  Base branch:   main
  Semantic ver.: True
--------------------------------

Info: Found 1 commits since  in main:
Info: No new commits have been pushed since the latest release (apart from the post release version bump) therefore skipping the tag.
```