### PR TITLE
Fix the action to not create empty releases

### DIFF
--- a/create_tag.py
+++ b/create_tag.py
@@ -172,6 +172,10 @@ def create_release_tag(args, repo, tag, latest_tag):
             f"Contributions from: {contributors}\n\n"
             f"— Somewhere on the Internet, {today.strftime('%Y-%m-%d')}")
 
+    if args.dry_run:
+        msg_info(f"DRY_RUN: Would create a tag '{tag}' with message:\n{message}")
+        return
+
     res = run_command(['git', 'tag', '-m', message, tag, 'HEAD'])
     logging.debug(res)
     msg_ok(f"Created tag '{tag}' with message:\n{message}")
@@ -218,6 +222,7 @@ def get_parser():
 def main():
     """Main function"""
     parser = get_parser()
+    global args
     args = parser.parse_args()
 
     logging.basicConfig(level=args.loglevel, format='%(asctime)s %(message)s', datefmt='%Y/%m/%d/ %H:%M:%S')
@@ -233,15 +238,16 @@ def main():
 
     print_config(args, repo)
 
-    if args.dry_run:
-        logging.info("Dry run, exiting...")
-        sys.exit(0)
-
     tag = f'v{args.version}'
     logging.debug(f"Current release: {latest_tag}\nNew release: {args.version}\nTag name: {tag}")
 
     # Create a release tag
     create_release_tag(args, repo, tag, latest_tag)
+
+    # Don't push the tag if we're doing a dry run
+    if args.dry_run:
+        msg_info(f"DRY_RUN: Would push a tag {tag} to branch {args.base}")
+        sys.exit(0)
 
     # Push the tag
     res = run_command(['git', 'push', 'origin', tag])

--- a/create_tag.py
+++ b/create_tag.py
@@ -185,11 +185,13 @@ def print_config(args, repo):
     """Print the values used for the release playbook"""
     print("\n--------------------------------\n"
           f"{fg.BOLD}Release:{fg.RESET}\n"
-          f"  Component:     {repo}\n"
-          f"  Version:       {args.version}\n"
-          f"  Base branch:   {args.base}\n"
-          f"  Semantic ver.: {args.semver}\n"
-          f"--------------------------------\n")
+          f"  Component:        {repo}\n"
+          f"  Version:          {args.version}\n"
+          f"  Base branch:      {args.base}\n"
+          f"  Semantic ver.:    {args.semver}")
+    if args.semver:
+        print(f"  Semver bump type: {args.semver_bump_type}")
+    print("--------------------------------\n")
 
 
 def get_parser():

--- a/create_tag.py
+++ b/create_tag.py
@@ -153,11 +153,11 @@ def create_release_tag(args, repo, tag, latest_tag):
     contributors = get_contributors(latest_tag)
 
     summaries = ""
-    hashes = run_command(['git', 'log', '--format=%H', f'{latest_tag}..HEAD']).split("\n")
+    hashes = run_command(['git', 'log', '--format=%H', f'{latest_tag}..HEAD']).splitlines()
     msg_info(f"Found {len(hashes)} commits since {latest_tag} in {args.base}:")
     logging.debug("\n".join(hashes))
 
-    subjects = run_command(['git', 'log', '--format=%s', f'{latest_tag}..HEAD']).split("\n")
+    subjects = run_command(['git', 'log', '--format=%s', f'{latest_tag}..HEAD']).splitlines()
     # Don't release when there are no changes
     if (len(hashes) < 1) or (len(subjects) == 1 and subjects[0] == "Post release version bump"):
         msg_info("No new commits have been pushed since the latest release (apart from the post release version bump) therefore skipping the tag.")


### PR DESCRIPTION
There was a bug in the code which made the code behave as if there was one commit since the last release in case there were no actual commits since the last release.

Add a few enhancements helping with debugging and testing the script.