### PR TITLE
Don't use `git describe` to get the latest tag in the repo

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 ghapi
+packaging


### PR DESCRIPTION
`git describe` gets confused when the same commit have more than one
tag. In such case, it may or may not return the latest tag.

In [1], the action detected the v0.2.0 tag as the latest, while there
was already the v0.3.0 tag attached to the same commit. As a result, the
action tried to recreate the v0.3.0 tag, which already exists in the
repo. The action does that every time it is run in the repo.

Move to using `git tag -l --merged` to get all tags in the repo, which are
reachable from the current commit. Sort them in the ascending order and take
the last item from the list as the latest tag.

Use `packaging.Version` to represent releases. This makes sorting of the
list of existing releases to produce expected results. In addition,
refactor the `autoincrement_version()` to also use `packaging.Version`
when parsing the latest version and bumping it. As a side-effect, a bug
with "simple dot-release" is fixed, when the code bumped only the last
digit in the latest version, not the whole number after the last dot.

[1] https://github.com/osbuild/images/actions/runs/5995856979/job/16259501077