### PR TITLE
[Create Tag] better support creating "dot" release on a specific branch

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,6 +47,8 @@ runs:
       shell: bash
 
     - name: Create and push tag
+      env:
+        BASE_BRANCH: ${{ env.GITHUB_REF_NAME }}
       run: |
         cd ${{ github.action_path }}/${{ env.REPOSITORY_NAME }}/
         if [[ "${{ inputs.SEMVER }}" == "true" ]]; then
@@ -57,5 +59,8 @@ runs:
         if [[ "${{ inputs.SEMVER_BUMP_TYPE }}" != "" ]]; then
           VERSION_TYPE_OPTION="$VERSION_TYPE_OPTION --semver-bump-type ${{ inputs.SEMVER_BUMP_TYPE }}"
         fi
-        ${{ github.action_path }}/create_tag.py --token "${{ inputs.TOKEN }}" $VERSION_TYPE_OPTION
+        if [[ -n ${{ env.BASE_BRANCH }} ]]; then
+          BASE_BRANCH_OPTION="--base ${{ env.BASE_BRANCH }}"
+        fi
+        ${{ github.action_path }}/create_tag.py --token "${{ inputs.TOKEN }}" $VERSION_TYPE_OPTION $BASE_BRANCH_OPTION
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,10 @@ inputs:
     description: "The type of semantic versioning bump to perform. Can be 'major', 'minor', or 'patch'."
     required: false
     default: "major"
+  version:
+    description: "The version to set. If not provided, the version will be determined automatically."
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -49,6 +53,7 @@ runs:
     - name: Create and push tag
       env:
         BASE_BRANCH: ${{ env.GITHUB_REF_NAME }}
+        VERSION: ${{ inputs.VERSION }}
       run: |
         cd ${{ github.action_path }}/${{ env.REPOSITORY_NAME }}/
         if [[ "${{ inputs.SEMVER }}" == "true" ]]; then
@@ -62,5 +67,8 @@ runs:
         if [[ -n ${{ env.BASE_BRANCH }} ]]; then
           BASE_BRANCH_OPTION="--base ${{ env.BASE_BRANCH }}"
         fi
-        ${{ github.action_path }}/create_tag.py --token "${{ inputs.TOKEN }}" $VERSION_TYPE_OPTION $BASE_BRANCH_OPTION
+        if [[ -n ${{ env.VERSION }} ]]; then
+          VERSION_OPTION="--version ${{ env.VERSION }}"
+        fi
+        ${{ github.action_path }}/create_tag.py --token "${{ inputs.TOKEN }}" $VERSION_TYPE_OPTION $BASE_BRANCH_OPTION $VERSION_OPTION
       shell: bash

--- a/create_tag.py
+++ b/create_tag.py
@@ -297,13 +297,13 @@ def main():
 
     # Don't push the tag if we're doing a dry run
     if args.dry_run:
-        msg_info(f"DRY_RUN: Would push a tag {tag} to branch {args.base}")
+        msg_info(f"DRY_RUN: Would push a tag {tag} to remote {args.remote}")
         sys.exit(0)
 
     # Push the tag
     res = run_command(['git', 'push', args.remote, tag])
     logging.debug(res)
-    msg_ok(f"Pushed tag '{tag}' to branch '{args.base}'")
+    msg_ok(f"Pushed tag '{tag}' to remote '{args.remote}'")
 
 
 if __name__ == "__main__":

--- a/create_tag.py
+++ b/create_tag.py
@@ -267,18 +267,19 @@ def main():
 
     # Get some basic fallback/default values
     repo = os.path.basename(os.getcwd())
-    if args.version is None:
-        latest_version = None
-        try:
-            # list all tags reachable from the current commit.
-            tags = run_command(['git', 'tag', '-l', '--merged'], check=True).splitlines()
-            if tags:
-                versions = [Version(tag) for tag in tags]
-                versions.sort()
-                latest_version = str(versions[-1])
-        except subprocess.CalledProcessError as e:
-            logging.error("Failed to get the list of tags from the repository: %s", e.stderr)
 
+    latest_version = None
+    try:
+        # list all tags reachable from the current commit.
+        tags = run_command(['git', 'tag', '-l', '--merged'], check=True).splitlines()
+        if tags:
+            versions = [Version(tag) for tag in tags]
+            versions.sort()
+            latest_version = str(versions[-1])
+    except subprocess.CalledProcessError as e:
+        logging.error("Failed to get the list of tags from the repository: %s", e.stderr)
+
+    if args.version is None:
         args.version = autoincrement_version(latest_version, args.semver, args.semver_bump_type)
 
     tag = f'v{args.version}'

--- a/create_tag.py
+++ b/create_tag.py
@@ -255,6 +255,9 @@ def get_parser():
                         action="store_true",
                         default=False,
                         help="Don't actually create the tag, just print the values that would be used.")
+    parser.add_argument("--remote",
+                        default="origin",
+                        help="Push the tag to this remote (default: 'origin').")
     return parser
 
 def main():
@@ -298,7 +301,7 @@ def main():
         sys.exit(0)
 
     # Push the tag
-    res = run_command(['git', 'push', 'origin', tag])
+    res = run_command(['git', 'push', args.remote, tag])
     logging.debug(res)
     msg_ok(f"Pushed tag '{tag}' to branch '{args.base}'")
 


### PR DESCRIPTION
We tend to use "dot" releases for versions that are then used for RHEL ZStream updates. These releases usually have a version that just appends a number to the original upstream version. I.e. `v141` release would be updated to `v141.1`.

The script does not support creating the first "dot" release as part of the release action, so one has to run it locally. This revealed a few shortcomings, which this PR addresses. Specifically:

- Always determine the latest version from the release tags to get a nice and sane release changelog.
- Allow one to specify the git remote to which to push the new tag. Some people have `origin` set up as read-only.
- Do not default to using `main` as the base branch to determine PRs for the changelog; instead, use the branch that triggered the action.
- Allow action users to specify the version to update explicitly. This will be especially useful for making the first "dot" release manually from a `rhel-x.y` branch and will remove the need to run the action script locally.