### PR TITLE
Correctly handle versions with a dot when bumping the version

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ It does the following:
 
   * Extracts the release note text from the git tag
   * Creates a GitHub release based on the tag information
-  * Automatically bumps the version (where applicable) and commits this change
+  * Automatically bumps the version (where applicable) and commits this change. If the version contains a dot, then the last part of the version is incremented.

--- a/bump-version.sh
+++ b/bump-version.sh
@@ -1,6 +1,18 @@
 #!/bin/bash
 
-VERSION=$(( $1 + 1 ))
+if [ -z "$1" ]; then
+  echo "Usage: $0 <version>"
+  exit 1
+fi
+
+if [[ "$1" =~ \. ]]; then
+  # If there is a "dot" in the version number, we need to bump the last number
+  VERSION=$(echo "$1" | sed -E 's/(.*\.)([0-9]+)$/echo "\1$((\2+1))"/e')
+else
+  # If there is no "dot" in the version number, we simply increment the version number
+  VERSION=$(( $1 + 1 ))
+fi
+
 
 find -name "*osbuild*.spec" -or -name "cockpit-*.spec" \
     | xargs sed -i -E "s/(Version:\\s+)[0-9]+/\1$VERSION/"


### PR DESCRIPTION
Enhance the `bump-version.sh` script to handle versions with a dot in it. In such case, the last number after the dot is increased by one.

Previously, the action would fail with [1]:
```
bump-version.sh: line 3: 141.1 + 1 : syntax error: invalid arithmetic operator (error token is ".1 + 1 ")
```

[1] https://github.com/osbuild/osbuild/actions/runs/14189258911/job/39750153675