### PR TITLE
create-tag: use dashes instead of asterisks (HMS-6052)

### DIFF
--- a/create_tag.py
+++ b/create_tag.py
@@ -170,12 +170,9 @@ def get_pullrequest_infos(args, repo, hashes):
             if author == "dependabot[bot]" and reviewers == ["github-actions[bot]"]:
                 author_reviewers_line = "Automated dependency update"
 
-            if repo == "cockpit-composer":
-                msg = (f"- {pr_title_line}\n"
-                       f"  - {author_reviewers_line}")
-            else:
-                msg = (f"  - {pr_title_line}\n"
-                       f"    - {author_reviewers_line}")
+            msg = (f"  - {pr_title_line}\n"
+                   f"    - {author_reviewers_line}")
+
             summaries.append(msg)
 
     # Deduplicate the list of pr summaries and sort it


### PR DESCRIPTION
When creating a new tag our description uses `*`-asterisks to denote an unordered list. This clashes with the format used in RPM spec files where asterisks can have special meaning.

In some corner cases this leads to automatic tools not being able to parse the changelogs as we embed them.

This is a very minor change since `-`-dash is also a valid unordered list marker in markdown.