### PR TITLE
create-tag: go through `env`

### DIFF
--- a/create_tag.py
+++ b/create_tag.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 """Release bot"""
 


### PR DESCRIPTION
The `create_tag.py` script had an absolute path to a Python 3 interpreter. This complicates local development where a virtual environment is being used for dependency management.