### PR TITLE
action: support tag input for workflow_dispatch triggers

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,9 @@ inputs:
     description: "Branch to commit the version bump to"
     required: false
     default: 'main'
+  tag:
+    description: "The tag to release. Required for workflow_dispatch triggers where GITHUB_REF is a branch, not a tag."
+    required: false
   build_release_artifacts:
     description: "Run `make release_artifacts` and expect results in `release_artifacts/`"
     required: false
@@ -34,6 +37,8 @@ runs:
     - name: Generate release information
       run: ${{ github.action_path }}/release-info.sh
       shell: bash
+      env:
+        INPUT_TAG: ${{ inputs.tag }}
 
     - name: Build additional release artifacts (optionally)
       run: make release_artifacts
@@ -44,6 +49,7 @@ runs:
       # https://github.com/marketplace/actions/create-release
       uses: ncipollo/release-action@v1.14.0
       with:
+        tag: ${{ inputs.tag }}
         name: "${{  env.release_version }}"
         token: "${{ inputs.TOKEN }}"
         bodyFile: "release.md"

--- a/release-info.sh
+++ b/release-info.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-TAG=$(git describe "${GITHUB_REF}")
+TAG=${INPUT_TAG:-$(git describe "${GITHUB_REF}")}
 git tag --list --format="%(subject)%0a%(body)" $TAG | sed '/^-----BEGIN PGP SIGNATURE-----$/,$d' > release.md
 echo "release_version=${TAG//v}" >> $GITHUB_ENV
 echo "component=$(basename `git rev-parse --show-toplevel`)" >> $GITHUB_ENV


### PR DESCRIPTION
When triggered via workflow_dispatch, GITHUB_REF is a branch ref, not a tag ref. This causes release-info.sh and ncipollo/release-action to fail because neither can resolve a tag. Add an optional `tag` input and pass it through to both.