### PR TITLE
many: support semver/bump type (HMS-10850)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,14 @@ inputs:
   tag:
     description: "The tag to release. Required for workflow_dispatch triggers where GITHUB_REF is a branch, not a tag."
     required: false
+  semver:
+    description: "Use semantic versioning for the post-release version bump"
+    required: false
+    default: 'false'
+  semver_bump_type:
+    description: "The type of semantic versioning bump to perform: 'major', 'minor', or 'patch'"
+    required: false
+    default: 'patch'
   build_release_artifacts:
     description: "Run `make release_artifacts` and expect results in `release_artifacts/`"
     required: false
@@ -56,7 +64,12 @@ runs:
         artifacts: "release_artifacts/*"
 
     - name: Bump version
-      run: ${{ github.action_path }}/bump-version.sh "${{  env.release_version }}"
+      run: |
+        if [[ "${{ inputs.semver }}" == "true" ]]; then
+          ${{ github.action_path }}/bump-version.sh "${{ env.release_version }}" "${{ inputs.semver_bump_type }}"
+        else
+          ${{ github.action_path }}/bump-version.sh "${{ env.release_version }}"
+        fi
       shell: bash
 
     - name: Commit new version

--- a/bump-version.sh
+++ b/bump-version.sh
@@ -1,26 +1,47 @@
 #!/bin/bash
 
 if [ -z "$1" ]; then
-  echo "Usage: $0 <version>"
+  echo "Usage: $0 <version> [major|minor|patch]"
   exit 1
 fi
 
-if [[ "$1" =~ \. ]]; then
-  # If there is a "dot" in the version number, we need to bump the last number
-  VERSION=$(echo "$1" | sed -E 's/(.*\.)([0-9]+)$/echo "\1$((\2+1))"/e')
+CURRENT="$1"
+BUMP_TYPE="${2:-}"
+
+if [ -n "$BUMP_TYPE" ]; then
+  IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+  MINOR="${MINOR:-0}"
+  PATCH="${PATCH:-0}"
+
+  case "$BUMP_TYPE" in
+    major)
+      VERSION="$((MAJOR + 1)).0.0"
+      ;;
+    minor)
+      VERSION="${MAJOR}.$((MINOR + 1)).0"
+      ;;
+    patch)
+      VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
+      ;;
+    *)
+      echo "Error: bump type must be 'major', 'minor', or 'patch'"
+      exit 1
+      ;;
+  esac
+elif [[ "$CURRENT" =~ \. ]]; then
+  VERSION=$(echo "$CURRENT" | sed -E 's/(.*\.)([0-9]+)$/echo "\1$((\2+1))"/e')
 else
-  # If there is no "dot" in the version number, we simply increment the version number
-  VERSION=$(( $1 + 1 ))
+  VERSION=$(( CURRENT + 1 ))
 fi
 
 
 find -name "*osbuild*.spec" -or -name "cockpit-*.spec" -or -name "image-builder*.spec" \
-    | xargs sed -i -E "s/(Version:\\s+)[0-9]+/\1$VERSION/"
+    | xargs sed -i -E "s/(Version:\\s+)[0-9]+[0-9.]*/\1$VERSION/"
 
 if [ -f "setup.py" ]; then
-  sed -i -E "s/(version=\")[0-9]+/\1$VERSION/" setup.py
+  sed -i -E "s/(version=\")[0-9]+[0-9.]*/\1$VERSION/" setup.py
 fi
 
 if [ -f "osbuild/__init__.py" ]; then
-  sed -i -E "s/(__version__ = \")[0-9]+/\1$VERSION/" osbuild/__init__.py
+  sed -i -E "s/(__version__ = \")[0-9]+[0-9.]*/\1$VERSION/" osbuild/__init__.py
 fi


### PR DESCRIPTION
Support the same arguments as for the create-tag branch for the bump-version script so it can be configured to bump major/minor/patch. Default behavior stays the same.