### PR TITLE
bump-version: minor fix: variable reuse

### DIFF
--- a/bump-version.sh
+++ b/bump-version.sh
@@ -55,5 +55,5 @@ if [ -f "go.mod" ] && (( NEW_MAJOR > 1 )); then
     # slice off version if it already has one
     module="$(sed -E 's/\/v[0-9]+$//' <<< "${module}")"
 
-    go mod edit -module "${module}/v$((MAJOR + 1))"
+    go mod edit -module "${module}/v${NEW_MAJOR}"
 fi


### PR DESCRIPTION
Minor thing I noticed after the last PR got merged.

We already have $NEW_MAJOR, so there's no need to recalculate it.